### PR TITLE
implement destination

### DIFF
--- a/packages/destination-actions/src/destinations/chartmogul/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/chartmogul/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-chartmogul destination: sendContact action - all fields 1`] = `
+Object {
+  "anonymous_id": "sCFIdyQr",
+  "company": Object {
+    "id": "sCFIdyQr",
+    "name": "sCFIdyQr",
+  },
+  "email": "puh@bak.bn",
+  "first_name": "sCFIdyQr",
+  "last_name": "sCFIdyQr",
+  "linked_in": "sCFIdyQr",
+  "message_id": "sCFIdyQr",
+  "name": "sCFIdyQr",
+  "phone": "sCFIdyQr",
+  "sent_at": "2021-02-01T00:00:00.000Z",
+  "timestamp": "2021-02-01T00:00:00.000Z",
+  "title": "sCFIdyQr",
+  "twitter": "sCFIdyQr",
+  "type": "sCFIdyQr",
+  "user_id": "sCFIdyQr",
+}
+`;
+
+exports[`Testing snapshot for actions-chartmogul destination: sendContact action - required fields 1`] = `
+Object {
+  "anonymous_id": "sCFIdyQr",
+  "message_id": "sCFIdyQr",
+  "sent_at": "2021-02-01T00:00:00.000Z",
+  "timestamp": "2021-02-01T00:00:00.000Z",
+  "type": "sCFIdyQr",
+  "user_id": "sCFIdyQr",
+}
+`;
+
+exports[`Testing snapshot for actions-chartmogul destination: sendCustomer action - all fields 1`] = `
+Object {
+  "address": Object {
+    "city": "jbl@p6u",
+    "country": "jbl@p6u",
+    "postal_code": "jbl@p6u",
+    "state": "jbl@p6u",
+    "street": "jbl@p6u",
+  },
+  "created_at": "2021-02-01T00:00:00.000Z",
+  "description": "jbl@p6u",
+  "email": "el@di.as",
+  "group_id": "jbl@p6u",
+  "message_id": "jbl@p6u",
+  "name": "jbl@p6u",
+  "sent_at": "2021-02-01T00:00:00.000Z",
+  "timestamp": "2021-02-01T00:00:00.000Z",
+  "type": "jbl@p6u",
+  "user_id": "jbl@p6u",
+  "website": "jbl@p6u",
+}
+`;
+
+exports[`Testing snapshot for actions-chartmogul destination: sendCustomer action - required fields 1`] = `
+Object {
+  "group_id": "jbl@p6u",
+  "message_id": "jbl@p6u",
+  "sent_at": "2021-02-01T00:00:00.000Z",
+  "timestamp": "2021-02-01T00:00:00.000Z",
+  "type": "jbl@p6u",
+  "user_id": "jbl@p6u",
+}
+`;

--- a/packages/destination-actions/src/destinations/chartmogul/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/__tests__/index.test.ts
@@ -1,0 +1,37 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Chart Mogul', () => {
+  describe('testAuthentication', () => {
+    it('should validate that chartmogul_webhook_url starts with https://', async () => {
+      try {
+        await testDestination.testAuthentication({ chartmogul_webhook_url: 'httpp://wh.endpoint' })
+      } catch (err: any) {
+        expect(err.message).toContain('Please configure the ChartMogul webhook URL')
+      }
+    }),
+      it('should test that authentication works', async () => {
+        nock('https://chartmogul.webhook.endpoint').post('/').reply(200, {})
+
+        const authData = { chartmogul_webhook_url: 'https://chartmogul.webhook.endpoint' }
+
+        await expect(testDestination.testAuthentication(authData)).resolves.not.toThrowError()
+      }),
+      it('should test that authentication fails', async () => {
+        nock('https://wrong.chartmogul.webhook.endpoint')
+          .post('/')
+          .reply(403, { errors: [{ field: null, message: 'access forbidden' }] })
+
+        const authData = { chartmogul_webhook_url: 'https://wrong.chartmogul.webhook.endpoint' }
+
+        try {
+          await testDestination.testAuthentication(authData)
+        } catch (err: any) {
+          expect(err.message).toContain('Credentials are invalid')
+        }
+      })
+  })
+})

--- a/packages/destination-actions/src/destinations/chartmogul/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/__tests__/snapshot.test.ts
@@ -1,0 +1,81 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-chartmogul'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+      // set the chartmogul_webhook_url to a valid URL
+      settingsData.chartmogul_webhook_url = 'https://chartmogul.webhook.endpoint'
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+      // set the chartmogul_webhook_url to a valid URL
+      settingsData.chartmogul_webhook_url = 'https://chartmogul.webhook.endpoint'
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/chartmogul/common_fields.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/common_fields.ts
@@ -1,0 +1,58 @@
+import { InputField } from '@segment/actions-core/destination-kit/types'
+
+export const message_id: InputField = {
+  label: 'MessageId',
+  description: 'The Segment message id. This field is required',
+  type: 'string',
+  required: true,
+  default: { '@path': '$.messageId' }
+}
+
+export const timestamp: InputField = {
+  label: 'Event Timestamp',
+  description: 'The timestamp at which the event was created. This field is required',
+  type: 'datetime',
+  required: true,
+  default: { '@path': '$.timestamp' }
+}
+
+export const sent_at: InputField = {
+  label: 'Sent At',
+  description: 'When the event was sent',
+  type: 'datetime',
+  required: true,
+  default: { '@path': '$.sentAt' }
+}
+
+export const event_type = (default_value: string): InputField => {
+  return {
+    label: 'Event Type',
+    description: 'The type of event. This field is required',
+    type: 'string',
+    default: default_value,
+    required: true,
+    unsafe_hidden: true
+  }
+}
+
+export const user_id = (required_value: boolean): InputField => {
+  return {
+    label: 'User Id',
+    description: 'Segment User Id',
+    type: 'string',
+    readOnly: true,
+    required: required_value,
+    default: { '@path': '$.userId' }
+  }
+}
+
+export const anonymous_id = (required_value: boolean): InputField => {
+  return {
+    label: 'Anonymous Id',
+    description: 'Segment Anonymous Id',
+    type: 'string',
+    readOnly: true,
+    required: required_value,
+    default: { '@path': '$.anonymousId' }
+  }
+}

--- a/packages/destination-actions/src/destinations/chartmogul/common_fields.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/common_fields.ts
@@ -2,7 +2,7 @@ import { InputField } from '@segment/actions-core/destination-kit/types'
 
 export const message_id: InputField = {
   label: 'MessageId',
-  description: 'The Segment message id. This field is required',
+  description: 'The Segment message id',
   type: 'string',
   required: true,
   default: { '@path': '$.messageId' }
@@ -10,7 +10,7 @@ export const message_id: InputField = {
 
 export const timestamp: InputField = {
   label: 'Event Timestamp',
-  description: 'The timestamp at which the event was created. This field is required',
+  description: 'The timestamp at which the event was created',
   type: 'datetime',
   required: true,
   default: { '@path': '$.timestamp' }
@@ -24,35 +24,29 @@ export const sent_at: InputField = {
   default: { '@path': '$.sentAt' }
 }
 
-export const event_type = (default_value: string): InputField => {
-  return {
-    label: 'Event Type',
-    description: 'The type of event. This field is required',
-    type: 'string',
-    default: default_value,
-    required: true,
-    unsafe_hidden: true
-  }
+export const event_type: InputField = {
+  label: 'Event Type',
+  description: 'The type of event',
+  type: 'string',
+  default: 'Send ...',
+  required: true,
+  unsafe_hidden: true
 }
 
-export const user_id = (required_value: boolean): InputField => {
-  return {
-    label: 'User Id',
-    description: 'Segment User Id',
-    type: 'string',
-    readOnly: true,
-    required: required_value,
-    default: { '@path': '$.userId' }
-  }
+export const user_id: InputField = {
+  label: 'User Id',
+  description: 'Segment User Id',
+  type: 'string',
+  readOnly: true,
+  required: false,
+  default: { '@path': '$.userId' }
 }
 
-export const anonymous_id = (required_value: boolean): InputField => {
-  return {
-    label: 'Anonymous Id',
-    description: 'Segment Anonymous Id',
-    type: 'string',
-    readOnly: true,
-    required: required_value,
-    default: { '@path': '$.anonymousId' }
-  }
+export const anonymous_id: InputField = {
+  label: 'Anonymous Id',
+  description: 'Segment Anonymous Id',
+  type: 'string',
+  readOnly: true,
+  required: false,
+  default: { '@path': '$.anonymousId' }
 }

--- a/packages/destination-actions/src/destinations/chartmogul/generated-types.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * Copy the webhook URL from ChartMogul CRM and paste it here
+   * Copy the webhook URL from ChartMogul and paste it here
    */
   chartmogul_webhook_url: string
 }

--- a/packages/destination-actions/src/destinations/chartmogul/generated-types.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Copy the webhook URL from ChartMogul CRM and paste it here
+   */
+  chartmogul_webhook_url: string
+}

--- a/packages/destination-actions/src/destinations/chartmogul/index.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/index.ts
@@ -22,12 +22,12 @@ const destination: DestinationDefinition<Settings> = {
       }
     },
     testAuthentication: (request, auth) => {
-      const target_url = auth?.settings?.chartmogul_webhook_url
-      if (!target_url || !target_url.startsWith('https://')) {
+      const targetUrl = auth?.settings?.chartmogul_webhook_url
+      if (!targetUrl || !targetUrl.startsWith('https://')) {
         throw new InvalidAuthenticationError('Please configure the ChartMogul webhook URL.')
       }
 
-      return request(target_url, {
+      return request(targetUrl, {
         method: 'post',
         json: {}
       })

--- a/packages/destination-actions/src/destinations/chartmogul/index.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/index.ts
@@ -1,0 +1,43 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+import { InvalidAuthenticationError } from '@segment/actions-core'
+
+import sendContact from './sendContact'
+
+import sendCustomer from './sendCustomer'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Chart Mogul',
+  slug: 'actions-chartmogul',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      chartmogul_webhook_url: {
+        label: 'ChartMogul webhook URL',
+        description: 'Copy the webhook URL from ChartMogul CRM and paste it here',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: (request, auth) => {
+      const target_url = auth?.settings?.chartmogul_webhook_url
+      if (!target_url || !target_url.startsWith('https://')) {
+        throw new InvalidAuthenticationError('Please configure the ChartMogul webhook URL.')
+      }
+
+      return request(target_url, {
+        method: 'post',
+        json: {}
+      })
+    }
+  },
+
+  actions: {
+    sendContact,
+    sendCustomer
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/chartmogul/index.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/index.ts
@@ -16,7 +16,7 @@ const destination: DestinationDefinition<Settings> = {
     fields: {
       chartmogul_webhook_url: {
         label: 'ChartMogul webhook URL',
-        description: 'Copy the webhook URL from ChartMogul CRM and paste it here',
+        description: 'Copy the webhook URL from ChartMogul and paste it here',
         type: 'string',
         required: true
       }

--- a/packages/destination-actions/src/destinations/chartmogul/sendContact/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/chartmogul/sendContact/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Chartmogul's sendContact destination action: all fields 1`] = `
+Object {
+  "anonymous_id": "xd0rHoH^PTr",
+  "company": Object {
+    "id": "xd0rHoH^PTr",
+    "name": "xd0rHoH^PTr",
+  },
+  "email": "vuha@telwozok.in",
+  "first_name": "xd0rHoH^PTr",
+  "last_name": "xd0rHoH^PTr",
+  "linked_in": "xd0rHoH^PTr",
+  "message_id": "xd0rHoH^PTr",
+  "name": "xd0rHoH^PTr",
+  "phone": "xd0rHoH^PTr",
+  "sent_at": "2021-02-01T00:00:00.000Z",
+  "timestamp": "2021-02-01T00:00:00.000Z",
+  "title": "xd0rHoH^PTr",
+  "twitter": "xd0rHoH^PTr",
+  "type": "xd0rHoH^PTr",
+  "user_id": "xd0rHoH^PTr",
+}
+`;
+
+exports[`Testing snapshot for Chartmogul's sendContact destination action: required fields 1`] = `
+Object {
+  "anonymous_id": "xd0rHoH^PTr",
+  "message_id": "xd0rHoH^PTr",
+  "sent_at": "2021-02-01T00:00:00.000Z",
+  "timestamp": "2021-02-01T00:00:00.000Z",
+  "type": "xd0rHoH^PTr",
+  "user_id": "xd0rHoH^PTr",
+}
+`;

--- a/packages/destination-actions/src/destinations/chartmogul/sendContact/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendContact/__tests__/index.test.ts
@@ -1,0 +1,89 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const CHARTMOGUL_WEBHOOK_URL = 'https://chartmogul.webhook.endpoint'
+const MINIMAL_MAPPING = {
+  type: 'Send Contact',
+  message_id: '1',
+  timestamp: '2024-01-01T10:00:00Z',
+  sent_at: '2024-01-01T10:01:00Z'
+}
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Chartmogul.sendContact', () => {
+  it('validates action fields', async () => {
+    try {
+      await testDestination.testAction('sendContact', {
+        settings: { chartmogul_webhook_url: CHARTMOGUL_WEBHOOK_URL }
+      })
+    } catch (err: any) {
+      expect(err.message).toContain("missing the required field 'type'.")
+      expect(err.message).toContain("missing the required field 'message_id'.")
+      expect(err.message).toContain("missing the required field 'timestamp'.")
+      expect(err.message).toContain("missing the required field 'sent_at'.")
+    }
+  })
+
+  it('requires user_id or anonymous_id', async () => {
+    try {
+      await testDestination.testAction('sendContact', {
+        mapping: { ...MINIMAL_MAPPING },
+        settings: { chartmogul_webhook_url: CHARTMOGUL_WEBHOOK_URL }
+      })
+    } catch (err: any) {
+      expect(err.message).toContain('The user_id and/or anonymous_id must be present.')
+    }
+  })
+
+  it('requires more than the required fields and the user_id', async () => {
+    try {
+      await testDestination.testAction('sendContact', {
+        mapping: { ...MINIMAL_MAPPING, user_id: 'u1' },
+        settings: { chartmogul_webhook_url: CHARTMOGUL_WEBHOOK_URL }
+      })
+    } catch (err: any) {
+      expect(err.message).toContain('The event does not contains useful information.')
+    }
+  })
+
+  it('requires more than the required fields and the anonymous_id', async () => {
+    try {
+      await testDestination.testAction('sendContact', {
+        mapping: { ...MINIMAL_MAPPING, anonymous_id: 'a1' },
+        settings: { chartmogul_webhook_url: CHARTMOGUL_WEBHOOK_URL }
+      })
+    } catch (err: any) {
+      expect(err.message).toContain('The event does not contains useful information.')
+    }
+  })
+
+  it('accepts the required fields, the user_id and the anonymous_id', async () => {
+    const mapping = { ...MINIMAL_MAPPING, user_id: 'u1', anonymous_id: 'a1' }
+    nock(CHARTMOGUL_WEBHOOK_URL).post('/', mapping).reply(200, {})
+
+    await testDestination.testAction('sendContact', {
+      mapping: mapping,
+      settings: { chartmogul_webhook_url: CHARTMOGUL_WEBHOOK_URL }
+    })
+  })
+
+  it('removes from the payload companies without id', async () => {
+    const mapping = {
+      ...MINIMAL_MAPPING,
+      user_id: 'u1',
+      anonymous_id: 'a1',
+      name: 'John Doe',
+      company: { name: 'Soft Tech' }
+    }
+    const optimized_mapping = { ...MINIMAL_MAPPING, user_id: 'u1', anonymous_id: 'a1', name: 'John Doe' }
+
+    nock(CHARTMOGUL_WEBHOOK_URL).post('/', optimized_mapping).reply(200, {})
+
+    await testDestination.testAction('sendContact', {
+      mapping: mapping,
+      settings: { chartmogul_webhook_url: CHARTMOGUL_WEBHOOK_URL }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/chartmogul/sendContact/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendContact/__tests__/index.test.ts
@@ -44,7 +44,7 @@ describe('Chartmogul.sendContact', () => {
         settings: { chartmogul_webhook_url: CHARTMOGUL_WEBHOOK_URL }
       })
     } catch (err: any) {
-      expect(err.message).toContain('The event does not contains useful information.')
+      expect(err.message).toContain('The event contains no information of interest to Chartmogul.')
     }
   })
 
@@ -55,7 +55,7 @@ describe('Chartmogul.sendContact', () => {
         settings: { chartmogul_webhook_url: CHARTMOGUL_WEBHOOK_URL }
       })
     } catch (err: any) {
-      expect(err.message).toContain('The event does not contains useful information.')
+      expect(err.message).toContain('The event contains no information of interest to Chartmogul.')
     }
   })
 

--- a/packages/destination-actions/src/destinations/chartmogul/sendContact/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendContact/__tests__/snapshot.test.ts
@@ -1,0 +1,79 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'sendContact'
+const destinationSlug = 'Chartmogul'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+    // set the chartmogul_webhook_url to a valid URL
+    settingsData.chartmogul_webhook_url = 'https://chartmogul.webhook.endpoint'
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+    // set the chartmogul_webhook_url to a valid URL
+    settingsData.chartmogul_webhook_url = 'https://chartmogul.webhook.endpoint'
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/chartmogul/sendContact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendContact/generated-types.ts
@@ -2,15 +2,15 @@
 
 export interface Payload {
   /**
-   * The type of event. This field is required
+   * The type of event
    */
   type: string
   /**
-   * The Segment message id. This field is required
+   * The Segment message id
    */
   message_id: string
   /**
-   * The timestamp at which the event was created. This field is required
+   * The timestamp at which the event was created
    */
   timestamp: string | number
   /**

--- a/packages/destination-actions/src/destinations/chartmogul/sendContact/generated-types.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendContact/generated-types.ts
@@ -1,0 +1,67 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The type of event. This field is required
+   */
+  type: string
+  /**
+   * The Segment message id. This field is required
+   */
+  message_id: string
+  /**
+   * The timestamp at which the event was created. This field is required
+   */
+  timestamp: string | number
+  /**
+   * When the event was sent
+   */
+  sent_at: string | number
+  /**
+   * Segment User Id
+   */
+  user_id?: string
+  /**
+   * Segment Anonymous Id
+   */
+  anonymous_id?: string
+  /**
+   * The user's email
+   */
+  email?: string
+  /**
+   * The contact's first name
+   */
+  first_name?: string
+  /**
+   * The contact's last name
+   */
+  last_name?: string
+  /**
+   * The contact's full name. It is used if first_name and last_name are not provided.
+   */
+  name?: string
+  /**
+   * The contact's job or personal title
+   */
+  title?: string
+  /**
+   * The contact's phone number
+   */
+  phone?: string
+  /**
+   * The contact's LinkedIn URL
+   */
+  linked_in?: string
+  /**
+   * The contact's Twitter (X) URL or handle
+   */
+  twitter?: string
+  /**
+   * The contact's Company. It creates a Customer in ChartMogul if the company id is present.
+   */
+  company?: {
+    id?: string
+    name?: string
+  }
+}

--- a/packages/destination-actions/src/destinations/chartmogul/sendContact/index.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendContact/index.ts
@@ -84,7 +84,6 @@ const action: ActionDefinition<Settings, Payload> = {
     }
   },
   perform: (request, data) => {
-    console.log(data.payload)
     if (!data.payload.user_id && !data.payload.anonymous_id) {
       throw new PayloadValidationError(`The user_id and/or anonymous_id must be present`)
     }

--- a/packages/destination-actions/src/destinations/chartmogul/sendContact/index.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendContact/index.ts
@@ -95,7 +95,7 @@ const action: ActionDefinition<Settings, Payload> = {
     // we definitely map type, message_id, timestamp, sent_at, and (user_id or anonymous_id)
     // A mapping containing only these fields is not useful.
     if (Object.keys(data.payload).length <= 5) {
-      throw new PayloadValidationError('The event does not contains useful information.')
+      throw new PayloadValidationError('The event contains no information of interest to Chartmogul.')
     }
 
     return request(data.settings.chartmogul_webhook_url, {

--- a/packages/destination-actions/src/destinations/chartmogul/sendContact/index.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendContact/index.ts
@@ -1,0 +1,109 @@
+import { ActionDefinition, PayloadValidationError } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { event_type, message_id, timestamp, sent_at, user_id, anonymous_id } from '../common_fields'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Send Contact',
+  description: 'Send a Contact to ChartMogul CRM',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    type: event_type('Send Contact'),
+    message_id,
+    timestamp,
+    sent_at,
+    user_id: user_id(false),
+    anonymous_id: anonymous_id(false),
+    email: {
+      label: 'Email',
+      description: "The user's email",
+      type: 'string',
+      format: 'email',
+      default: { '@path': '$.traits.email' }
+    },
+    first_name: {
+      label: 'First Name',
+      description: `The contact's first name`,
+      type: 'string',
+      default: { '@path': '$.traits.firstName' }
+    },
+    last_name: {
+      label: 'Last Name',
+      description: "The contact's last name",
+      type: 'string',
+      default: { '@path': '$.traits.lastName' }
+    },
+    name: {
+      label: 'Full Name',
+      description: "The contact's full name. It is used if first_name and last_name are not provided.",
+      type: 'string',
+      default: { '@path': '$.traits.name' }
+    },
+    title: {
+      label: 'Title',
+      description: `The contact's job or personal title`,
+      type: 'string',
+      default: { '@path': '$.traits.title' }
+    },
+    phone: {
+      label: 'Phone Number',
+      description: "The contact's phone number",
+      type: 'string',
+      default: { '@path': '$.traits.phone' }
+    },
+    linked_in: {
+      label: 'LinkedIn',
+      description: "The contact's LinkedIn URL",
+      type: 'string',
+      default: { '@path': '$.traits.linkedIn' }
+    },
+    twitter: {
+      label: 'Twitter (X)',
+      description: "The contact's Twitter (X) URL or handle",
+      type: 'string',
+      default: { '@path': '$.traits.twitter' }
+    },
+    company: {
+      label: 'Company',
+      description: "The contact's Company. It creates a Customer in ChartMogul if the company id is present.",
+      type: 'object',
+      properties: {
+        id: {
+          label: 'Company Id',
+          type: 'string'
+        },
+        name: {
+          label: 'Company Name',
+          type: 'string'
+        }
+      },
+      default: {
+        id: { '@path': '$.traits.company.id' },
+        name: { '@path': '$.traits.company.name' }
+      }
+    }
+  },
+  perform: (request, data) => {
+    console.log(data.payload)
+    if (!data.payload.user_id && !data.payload.anonymous_id) {
+      throw new PayloadValidationError(`The user_id and/or anonymous_id must be present`)
+    }
+
+    if (data.payload.company && !data.payload.company.id) {
+      delete data.payload.company
+    }
+
+    // we definitely map type, message_id, timestamp, sent_at, and (user_id or anonymous_id)
+    // A mapping containing only these fields is not useful.
+    if (Object.keys(data.payload).length <= 5) {
+      throw new PayloadValidationError('The payload contains no useful information')
+    }
+
+    return request(data.settings.chartmogul_webhook_url, {
+      method: 'post',
+      json: data.payload
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/chartmogul/sendContact/index.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendContact/index.ts
@@ -8,12 +8,12 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Send a Contact to ChartMogul CRM',
   defaultSubscription: 'type = "identify"',
   fields: {
-    type: event_type('Send Contact'),
+    type: { ...event_type, default: 'Send Contact' },
     message_id,
     timestamp,
     sent_at,
-    user_id: user_id(false),
-    anonymous_id: anonymous_id(false),
+    user_id,
+    anonymous_id,
     email: {
       label: 'Email',
       description: "The user's email",

--- a/packages/destination-actions/src/destinations/chartmogul/sendContact/index.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendContact/index.ts
@@ -85,7 +85,7 @@ const action: ActionDefinition<Settings, Payload> = {
   },
   perform: (request, data) => {
     if (!data.payload.user_id && !data.payload.anonymous_id) {
-      throw new PayloadValidationError(`The user_id and/or anonymous_id must be present`)
+      throw new PayloadValidationError(`The user_id and/or anonymous_id must be present.`)
     }
 
     if (data.payload.company && !data.payload.company.id) {
@@ -95,7 +95,7 @@ const action: ActionDefinition<Settings, Payload> = {
     // we definitely map type, message_id, timestamp, sent_at, and (user_id or anonymous_id)
     // A mapping containing only these fields is not useful.
     if (Object.keys(data.payload).length <= 5) {
-      throw new PayloadValidationError('The payload contains no useful information')
+      throw new PayloadValidationError('The event does not contains useful information.')
     }
 
     return request(data.settings.chartmogul_webhook_url, {

--- a/packages/destination-actions/src/destinations/chartmogul/sendCustomer/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/chartmogul/sendCustomer/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Chartmogul's sendCustomer destination action: all fields 1`] = `
+Object {
+  "address": Object {
+    "city": "nX10Ilka9K6F",
+    "country": "nX10Ilka9K6F",
+    "postal_code": "nX10Ilka9K6F",
+    "state": "nX10Ilka9K6F",
+    "street": "nX10Ilka9K6F",
+  },
+  "created_at": "2021-02-01T00:00:00.000Z",
+  "description": "nX10Ilka9K6F",
+  "email": "fiwhaebi@jemtu.ki",
+  "group_id": "nX10Ilka9K6F",
+  "message_id": "nX10Ilka9K6F",
+  "name": "nX10Ilka9K6F",
+  "sent_at": "2021-02-01T00:00:00.000Z",
+  "timestamp": "2021-02-01T00:00:00.000Z",
+  "type": "nX10Ilka9K6F",
+  "user_id": "nX10Ilka9K6F",
+  "website": "nX10Ilka9K6F",
+}
+`;
+
+exports[`Testing snapshot for Chartmogul's sendCustomer destination action: required fields 1`] = `
+Object {
+  "group_id": "nX10Ilka9K6F",
+  "message_id": "nX10Ilka9K6F",
+  "sent_at": "2021-02-01T00:00:00.000Z",
+  "timestamp": "2021-02-01T00:00:00.000Z",
+  "type": "nX10Ilka9K6F",
+  "user_id": "nX10Ilka9K6F",
+}
+`;

--- a/packages/destination-actions/src/destinations/chartmogul/sendCustomer/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendCustomer/__tests__/index.test.ts
@@ -1,0 +1,42 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+
+const CHARTMOGUL_WEBHOOK_URL = 'https://chartmogul.webhook.endpoint'
+const testDestination = createTestIntegration(Destination)
+
+describe('Chartmogul.sendCustomer', () => {
+  it('validates action fields', async () => {
+    try {
+      await testDestination.testAction('sendCustomer', {
+        settings: { chartmogul_webhook_url: CHARTMOGUL_WEBHOOK_URL }
+      })
+    } catch (err: any) {
+      expect(err.message).toContain("missing the required field 'type'.")
+      expect(err.message).toContain("missing the required field 'message_id'.")
+      expect(err.message).toContain("missing the required field 'timestamp'.")
+      expect(err.message).toContain("missing the required field 'sent_at'.")
+      expect(err.message).toContain("missing the required field 'group_id'.")
+      expect(err.message).toContain("missing the required field 'user_id'.")
+    }
+  })
+
+  it('processes valid input', async () => {
+    const mapping = {
+      type: 'Send Customer',
+      message_id: '1',
+      timestamp: '2024-01-01T10:00:00Z',
+      sent_at: '2024-01-01T10:01:00Z',
+      group_id: 'g1',
+      user_id: 'u1',
+      name: 'Soft Tech'
+    }
+
+    nock(CHARTMOGUL_WEBHOOK_URL).post('/', mapping).reply(200, {})
+
+    await testDestination.testAction('sendCustomer', {
+      mapping: mapping,
+      settings: { chartmogul_webhook_url: CHARTMOGUL_WEBHOOK_URL }
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/chartmogul/sendCustomer/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendCustomer/__tests__/snapshot.test.ts
@@ -1,0 +1,79 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'sendCustomer'
+const destinationSlug = 'Chartmogul'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+    // set the chartmogul_webhook_url to a valid URL
+    settingsData.chartmogul_webhook_url = 'https://chartmogul.webhook.endpoint'
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+    // set the chartmogul_webhook_url to a valid URL
+    settingsData.chartmogul_webhook_url = 'https://chartmogul.webhook.endpoint'
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/chartmogul/sendCustomer/generated-types.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendCustomer/generated-types.ts
@@ -2,15 +2,15 @@
 
 export interface Payload {
   /**
-   * The type of event. This field is required
+   * The type of event
    */
   type: string
   /**
-   * The Segment message id. This field is required
+   * The Segment message id
    */
   message_id: string
   /**
-   * The timestamp at which the event was created. This field is required
+   * The timestamp at which the event was created
    */
   timestamp: string | number
   /**
@@ -22,7 +22,7 @@ export interface Payload {
    */
   user_id: string
   /**
-   * Segment Group Id. This field is required
+   * Segment Group Id
    */
   group_id: string
   /**

--- a/packages/destination-actions/src/destinations/chartmogul/sendCustomer/generated-types.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendCustomer/generated-types.ts
@@ -1,0 +1,73 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The type of event. This field is required
+   */
+  type: string
+  /**
+   * The Segment message id. This field is required
+   */
+  message_id: string
+  /**
+   * The timestamp at which the event was created. This field is required
+   */
+  timestamp: string | number
+  /**
+   * When the event was sent
+   */
+  sent_at: string | number
+  /**
+   * Segment User Id
+   */
+  user_id: string
+  /**
+   * Segment Group Id. This field is required
+   */
+  group_id: string
+  /**
+   * The company's name
+   */
+  name?: string
+  /**
+   * The company's name
+   */
+  description?: string
+  /**
+   * The company's email
+   */
+  email?: string
+  /**
+   * The company's website URL
+   */
+  website?: string
+  /**
+   * Date the group’s account was first created
+   */
+  created_at?: string | number
+  /**
+   * The company’s address details
+   */
+  address?: {
+    /**
+     * The company’s street address
+     */
+    street?: string
+    /**
+     * The company’s city
+     */
+    city?: string
+    /**
+     * The company’s state or region
+     */
+    state?: string
+    /**
+     * The company’s zip or postal code
+     */
+    postal_code?: string
+    /**
+     * The company’s country
+     */
+    country?: string
+  }
+}

--- a/packages/destination-actions/src/destinations/chartmogul/sendCustomer/index.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendCustomer/index.ts
@@ -1,0 +1,103 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { event_type, message_id, timestamp, sent_at, user_id } from '../common_fields'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Send Customer',
+  description: 'Send a Customer (company) to ChartMogul CRM',
+  defaultSubscription: 'type = "group"',
+  fields: {
+    type: event_type('Send Customer'),
+    message_id,
+    timestamp,
+    sent_at,
+    user_id: user_id(true),
+    group_id: {
+      label: 'Group Id',
+      description: 'Segment Group Id. This field is required',
+      type: 'string',
+      required: true,
+      default: { '@path': '$.groupId' }
+    },
+    name: {
+      label: 'Name',
+      description: "The company's name",
+      type: 'string',
+      default: { '@path': '$.traits.name' }
+    },
+    description: {
+      label: 'Description',
+      description: "The company's name",
+      type: 'string',
+      default: { '@path': '$.traits.description' }
+    },
+    email: {
+      label: 'Email',
+      description: "The company's email",
+      type: 'string',
+      format: 'email',
+      default: { '@path': '$.traits.email' }
+    },
+    website: {
+      label: 'Website',
+      description: "The company's website URL",
+      type: 'string',
+      format: 'uri-reference',
+      default: { '@path': '$.traits.website' }
+    },
+    created_at: {
+      label: 'Created at',
+      description: 'Date the group’s account was first created',
+      type: 'datetime',
+      default: { '@path': '$.traits.createdAt' }
+    },
+    address: {
+      label: 'Address',
+      type: 'object',
+      description: 'The company’s address details',
+      properties: {
+        street: {
+          label: 'Street',
+          type: 'string',
+          description: 'The company’s street address'
+        },
+        city: {
+          label: 'City',
+          type: 'string',
+          description: 'The company’s city'
+        },
+        state: {
+          label: 'State',
+          type: 'string',
+          description: 'The company’s state or region'
+        },
+        postal_code: {
+          label: 'Postal code',
+          type: 'string',
+          description: 'The company’s zip or postal code'
+        },
+        country: {
+          label: 'Country',
+          type: 'string',
+          description: 'The company’s country'
+        }
+      },
+      default: {
+        street: { '@path': '$.traits.address.street' },
+        city: { '@path': '$.traits.address.city' },
+        state: { '@path': '$.traits.address.state' },
+        postal_code: { '@path': '$.traits.address.postalCode' },
+        country: { '@path': '$.traits.address.country' }
+      }
+    }
+  },
+  perform: (request, data) => {
+    return request(data.settings.chartmogul_webhook_url, {
+      method: 'post',
+      json: data.payload
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/chartmogul/sendCustomer/index.ts
+++ b/packages/destination-actions/src/destinations/chartmogul/sendCustomer/index.ts
@@ -8,14 +8,14 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Send a Customer (company) to ChartMogul CRM',
   defaultSubscription: 'type = "group"',
   fields: {
-    type: event_type('Send Customer'),
+    type: { ...event_type, default: 'Send Customer' },
     message_id,
     timestamp,
     sent_at,
-    user_id: user_id(true),
+    user_id: { ...user_id, required: true },
     group_id: {
       label: 'Group Id',
-      description: 'Segment Group Id. This field is required',
+      description: 'Segment Group Id',
       type: 'string',
       required: true,
       default: { '@path': '$.groupId' }


### PR DESCRIPTION
- Implemented two destinations: `Send Contact` (`Identify`) snd `Send Customer` (`Group`). 
- Auth setting to specify the CM webhook URL. `Test connection` works bysending an empty webhook to that URL.

Tested with our back-end. Main approach:
- minimize changes to our back-end (only a couple of lines for the new `type` names will be added
- ensure that destinations webhooks will continue to work


**Added tests**

TODO: 
- (Future) Add to auth an API key which should be supplied by our UI.  